### PR TITLE
Add timestamp to "iteration %d" message

### DIFF
--- a/mdtest.c
+++ b/mdtest.c
@@ -3475,7 +3475,7 @@ int main(int argc, char **argv) {
     }
     for (j = 0; j < iterations; j++) {
       if (rank == 0 && verbose >= 1) {
-	printf("V-1: main: * iteration %d *\n", j+1);
+	printf("V-1: main: * iteration %d %s *\n", j+1, timestamp());
 	fflush(stdout);
       }
             


### PR DESCRIPTION
Add the timestamp to this message, which is displayed when the -v flag
is used.

If the user is gathering data about the system being tested, e.g. via
sar, then the state of the system at the time the iteration started can
be examined.
